### PR TITLE
Allow files for investigations

### DIFF
--- a/app/views/report/allegation/_summary-card.html
+++ b/app/views/report/allegation/_summary-card.html
@@ -15,6 +15,28 @@
         html: d('report.allegation.allegation') | nl2br
       },
       href: "/report/allegation/allegation"
+    } if isPublic or d("report.allegation.how-tell") == "describe",
+    {
+      key: "Detailed account",
+      value: {
+        html: '<a href="#">investigation.pdf</a>'
+      },
+      href: "/report/allegation/allegation",
+      condition: {
+        data: "report.allegation.how-tell",
+        value: "upload"
+      }
+    },
+    {
+      key: "Detailed account",
+      value: {
+        html: '<span class="govuk-tag govuk-tag--grey">Incomplete</span>'
+      },
+      href: "/report/allegation/allegation",
+      condition: {
+        data: "report.allegation.how-tell",
+        value: "later"
+      }
     },
     {
       key: "Summary",

--- a/app/views/report/allegation/allegation.html
+++ b/app/views/report/allegation/allegation.html
@@ -1,27 +1,75 @@
 {% extends "layouts/report.html" %}
-{% set title = "Give a detailed account of what happened" %}
+{% set title = "Give a detailed account of what happened" if isPublic else "How do you want to tell us about your allegation?" %}
 
 {% block form %}
-  <h1 class="govuk-heading-xl">
-    {{ title }}
-  </h1>
+  {% set textarea %}
+    {{ govukTextarea({
+      label: {
+        text: title if isPublic else "Details of the allegation",
+        classes: "govuk-label--xl govuk-!-margin-top-6" if isPublic else "govuk-label--m govuk-!-margin-top-6",
+        isPageHeading: isPublic
+      },
+      hint: {
+        text: 'Include dates and locations'
+      },
+      decorate: 'report.allegation.allegation',
+      rows: 20,
+      validate: {
+        presence: {
+          message: "Tell us about the allegation"
+        }
+      }
+    }) }}
+  {% endset %}
 
-  <p>Include dates and locations.</p>
-  {% if isEmployer %}
-    <p>If you have this information in a document, you can upload it in the <a href="#">documentation section</a>.</p>
+  {% set fileUpload %}
+    {{ govukFileUpload({
+      label: {
+        text: "Upload allegation details",
+        classes: "govuk-label--s"
+      },
+      decorate: 'report.allegation.allegation-file'
+    }) }}
+  {% endset %}
+
+  {% if isPublic %}
+    {{ textarea | safe }}
+  {% else %}
+    {{ govukRadios({
+      fieldset: {
+        legend: {
+          classes: "govuk-fieldset__legend--xl govuk-!-margin-bottom-6",
+          isPageHeading: true,
+          text: title
+        }
+      },
+      items: [
+        {
+          text: "I’ll upload the allegation details",
+          value: "upload",
+          conditional: {
+            html: fileUpload
+          }
+        },
+        {
+          text: "I’ll give details of the allegation",
+          value: "describe",
+          conditional: {
+            html: textarea
+          }
+        },
+        {
+          text: "I’ll do this later",
+          value: "later"
+        }
+      ],
+      decorate: 'report.allegation.how-tell',
+      validate: {
+        presence: {
+          message: "Tell us about the allegation"
+        }
+      }
+    }) }}
   {% endif %}
 
-  {{ govukTextarea({
-    label: {
-      text: "Details of the allegation",
-      classes: "govuk-label--m govuk-!-margin-top-6"
-    },
-    decorate: 'report.allegation.allegation',
-    rows: 20,
-    validate: {
-      presence: {
-        message: "Tell us about the allegation"
-      }
-    }
-  }) }}
 {% endblock %}

--- a/app/views/report/previous-misconduct/_summary-card.html
+++ b/app/views/report/previous-misconduct/_summary-card.html
@@ -14,8 +14,30 @@
       },
       href: "/report/previous-misconduct/previous-misconduct",
       condition: {
-        data: "report.previous-misconduct.any-previous",
-        value: "Yes"
+        data: "report.previous-misconduct.how-tell",
+        value: "describe"
+      }
+    },
+    {
+      key: "Detailed report",
+      value: {
+        html: '<a href="#">previous-misconduct.pdf</a>'
+      },
+      href: "/report/previous-misconduct/previous-misconduct",
+      condition: {
+        data: "report.previous-misconduct.how-tell",
+        value: "upload"
+      }
+    },
+    {
+      key: "Detailed report",
+      value: {
+        html: '<span class="govuk-tag govuk-tag--grey">Incomplete</span>'
+      },
+      href: "/report/previous-misconduct/previous-misconduct",
+      condition: {
+        data: "report.previous-misconduct.how-tell",
+        value: "later"
       }
     },
     {

--- a/app/views/report/previous-misconduct/previous-misconduct.html
+++ b/app/views/report/previous-misconduct/previous-misconduct.html
@@ -24,18 +24,63 @@
     <li>reference numbers from previous referrals</li>
   </ul>
 
-  <p>If you have this information in a document, you can upload it in the documentation section.</p>
+  {% set textarea %}
+    {{ govukTextarea({
+      label: {
+        text: "Details of previous allegations",
+        classes: "govuk-label--m govuk-!-margin-top-6"
+      },
+      decorate: 'report.previous-misconduct.previous-misconduct',
+      rows: 20,
+      validate: {
+        presence: {
+          message: "Tell us about the previous misconduct"
+        }
+      }
+    }) }}
+  {% endset %}
 
-  {{ govukTextarea({
-    label: {
-      text: "Details of previous allegations",
-      classes: "govuk-label--m govuk-!-margin-top-6"
+  {% set fileUpload %}
+    {{ govukFileUpload({
+      label: {
+        text: "Upload details of previous allegations",
+        classes: "govuk-label--s"
+      },
+      decorate: 'report.previous-misconduct.previous-misconduct-file'
+    }) }}
+  {% endset %}
+
+  {{ govukRadios({
+    formGroup: {
+      classes: "govuk-!-margin-top-6"
     },
-    hint: {
-      text: ''
+    fieldset: {
+      legend: {
+        classes: "govuk-fieldset__legend--m",
+        text: "How do you want to tell us about previous allegations?"
+      }
     },
-    decorate: 'report.previous-misconduct.previous-misconduct',
-    rows: 20,
+    items: [
+      {
+        text: "I’ll upload the previous misconduct details",
+        value: "upload",
+        conditional: {
+          html: fileUpload
+        }
+      },
+      {
+        text: "I’ll give details of the previous misconduct",
+        value: "describe",
+        conditional: {
+          html: textarea
+        }
+      },
+      {
+        text: "I’ll do this later",
+        value: "later"
+      }
+    ],
+    decorate: 'report.previous-misconduct.how-tell',
     validate: {
       presence: {
         message: "Tell us about the previous misconduct"


### PR DESCRIPTION
When giving:

- detailed allegation
- details of previous misconduct

Use the job description pattern to allow:
- file upload
- text description
- or complete later (eg don't have file available)

For members of the public, they do not see previous misconduct section, and they only see a text description (we do not expect them to have files to upload here).

![localhost_3005_report_allegation_allegation (1)](https://user-images.githubusercontent.com/319055/190141372-73da1166-323e-427c-903b-c134bc047a19.png)
![localhost_3005_report_allegation_allegation](https://user-images.githubusercontent.com/319055/190141381-bff89eec-633d-411d-a9f8-2d609ae0be75.png)
![localhost_3005_report_previous-misconduct_previous-misconduct](https://user-images.githubusercontent.com/319055/190141386-672c1b74-1102-40af-8cf2-a0a6843e4fbd.png)
